### PR TITLE
implement check_num_cpus

### DIFF
--- a/src/sui-doctor.py
+++ b/src/sui-doctor.py
@@ -10,6 +10,7 @@ from spinner import Spinner
 # minimum limits checked by this script
 MINIMUM_NET_SPEED = 1000
 MINIMUM_DISK_READ_SPEED = 1000
+MINIMUM_CPU_THREADS = 48
 
 def script_dir():
   return pathlib.Path(__file__).parent.resolve()
@@ -69,7 +70,7 @@ def run_command(cmd, subdir=None):
 
   spinner = Spinner()
   spinner.start()
-  output = subprocess.run(cmd, cwd=cwd, capture_output=True)
+  output = subprocess.run(cmd, cwd=cwd, capture_output=True, shell=True)
   spinner.stop()
 
   # print stderr if there is any
@@ -146,8 +147,9 @@ def hdparm():
 def check_if_sui_db_on_nvme():
   return (False, "not implemented", None)
 
-def check_num_cpus():
-  return (False, "not implemented", None)
+def check_num_cpus() -> Tuple[bool, str, str]:
+  output = run_command(["cat /proc/cpuinfo | grep processor | wc -l"])
+  return (True, output, None) if int(output) >= MINIMUM_CPU_THREADS else (False, output, "48 CPU threads are required")
 
 def check_ram():
   return (False, "not implemented", None)


### PR DESCRIPTION
probably we can use `lscpu` here, but ill revisit that once some more resource based checks are added

```
ubuntu@lhr-tnt-val-00:~/sui-doctor$ ./src/sui-doctor.py
building tools...
make: Nothing to be done for 'all'.

Running command: check_clock_synchronization    [PASSED]
Max       error:    603000 (us)
Estimated error:         0 (us)
Clock precision:         1 (us)
Jitter:                  0 (ns)
Synchronized:          yes


Running command: check_net_speed    [PASSED]
Retrieving speedtest.net configuration...
Testing from Choopa, LLC (95.179.230.32)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by YouFibre (Manchester) [263.70 km]: 5.859 ms
Testing download speed................................................................................
Download: 5310.51 Mbit/s
Testing upload speed......................................................................................................
Upload: 2960.16 Mbit/s


Running command: hdparm stderr:
   [FAILED]

command failed with exception: can't concat str to bytes

Running command: check_if_sui_db_on_nvme   [FAILED]

not implemented

Running command: check_num_cpus    [PASSED]
48


Running command: check_ram   [FAILED]

not implemented

Running command: check_storage_space_for_suidb   [FAILED]

not implemented

Running command: check_for_packet_loss   [FAILED]

not implemented
```