### PR TITLE
implement check_ram

### DIFF
--- a/src/sui-doctor.py
+++ b/src/sui-doctor.py
@@ -11,6 +11,7 @@ from spinner import Spinner
 MINIMUM_NET_SPEED = 1000
 MINIMUM_DISK_READ_SPEED = 1000
 MINIMUM_CPU_THREADS = 48
+MINIMUM_MEM_TOTAL = 128000000
 
 def script_dir():
   return pathlib.Path(__file__).parent.resolve()
@@ -149,10 +150,11 @@ def check_if_sui_db_on_nvme():
 
 def check_num_cpus() -> Tuple[bool, str, str]:
   output = run_command(["cat /proc/cpuinfo | grep processor | wc -l"])
-  return (True, output, None) if int(output) >= MINIMUM_CPU_THREADS else (False, output, "48 CPU threads are required")
+  return (True, output, None) if int(output) >= MINIMUM_CPU_THREADS else (False, output, "sui-node requires >= 48 CPU threads")
 
-def check_ram():
-  return (False, "not implemented", None)
+def check_ram() -> Tuple[bool, str, str]:
+  output = run_command(["cat /proc/meminfo | grep MemTotal"])
+  return (True, output, None) if int(output.split()[1]) >= MINIMUM_MEM_TOTAL else (False, output, "sui-node requires >= 128G total memory")
 
 def check_storage_space_for_suidb():
   return (False, "not implemented", None)


### PR DESCRIPTION
depends on #3 (review that first)

i suppose the benefit of parsing procfs is its a little closer to a source of truth (e.g. vs `lsmem`)

```
ubuntu@lhr-tnt-val-00:~/sui-doctor$ ./src/sui-doctor.py
building tools...
make: Nothing to be done for 'all'.

Running command: check_clock_synchronization    [PASSED]
Max       error:    313500 (us)
Estimated error:         0 (us)
Clock precision:         1 (us)
Jitter:                  0 (ns)
Synchronized:          yes


Running command: check_net_speed    [PASSED]
Retrieving speedtest.net configuration...
Testing from Choopa, LLC (95.179.230.32)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by YouFibre (Manchester) [263.70 km]: 5.921 ms
Testing download speed................................................................................
Download: 5142.47 Mbit/s
Testing upload speed......................................................................................................
Upload: 2852.93 Mbit/s


Running command: hdparm stderr:
   [FAILED]

command failed with exception: can't concat str to bytes

Running command: check_if_sui_db_on_nvme   [FAILED]

not implemented

Running command: check_num_cpus    [PASSED]
48


Running command: check_ram    [PASSED]
MemTotal:       263532756 kB


Running command: check_storage_space_for_suidb   [FAILED]

not implemented

Running command: check_for_packet_loss   [FAILED]

not implemented
```