### PR TITLE
add code to check for nvme device types to skip hdparm as necesary

### DIFF
--- a/src/checks.py
+++ b/src/checks.py
@@ -75,7 +75,7 @@ def hdparm():
 
   # if mountpoint is attached to nvme-type disk, pass trivially
   if directory_on_nvme(mountpoint):
-    return (True, f"(SKIPPING check) sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {True}", None)
+    return (True, f"(SKIPPING check) sui DB dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {True}", None)
 
   output = run_command(["sudo", "hdparm", "-tT", "--direct", mountpoint])
 
@@ -108,7 +108,7 @@ def check_if_sui_db_on_nvme():
 
   # check if mountpoint is attached to nvme-type disk
   nvme = directory_on_nvme(mountpoint)
-  return (nvme, f"sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {nvme}", None)
+  return (nvme, f"sui DB dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {nvme}", None)
 
 
 def check_num_cpus() -> Tuple[bool, str, str]:

--- a/src/checks.py
+++ b/src/checks.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 from utils import (
     directory_to_mountpoint,
+    directory_on_nvme,
     find_sui_db_dir,
     parse_output,
     run_command,
@@ -67,8 +68,13 @@ def hdparm():
 
   # first find the sui db
   sui_db_dir = find_sui_db_dir()
+
   # get the mount point
   mountpoint = directory_to_mountpoint(sui_db_dir)
+
+  # if mountpoint is attached to nvme-type disk, pass trivially
+  if directory_on_nvme(mountpoint):
+    return (True, f"(SKIPPING check) sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {True}", None)
 
   output = run_command(["sudo", "hdparm", "-tT", "--direct", mountpoint])
 
@@ -93,7 +99,15 @@ def hdparm():
 
 
 def check_if_sui_db_on_nvme():
-  return (False, "not implemented", None)
+  # first find the sui db
+  sui_db_dir = find_sui_db_dir()
+
+  # get the mount point
+  mountpoint = directory_to_mountpoint(sui_db_dir)
+
+  # check if mountpoint is attached to nvme-type disk
+  nvme = mountpoint_on_nvme(mountpoint)
+  return (nvme, f"sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {nvme}", None)
 
 
 def check_num_cpus() -> Tuple[bool, str, str]:

--- a/src/checks.py
+++ b/src/checks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import re
+import pathlib
 
 from typing import Tuple
 
@@ -70,7 +71,7 @@ def hdparm():
   sui_db_dir = find_sui_db_dir()
 
   # get the mount point
-  mountpoint = directory_to_mountpoint(sui_db_dir)
+  mountpoint = pathlib.Path(directory_to_mountpoint(sui_db_dir))
 
   # if mountpoint is attached to nvme-type disk, pass trivially
   if directory_on_nvme(mountpoint):
@@ -103,10 +104,10 @@ def check_if_sui_db_on_nvme():
   sui_db_dir = find_sui_db_dir()
 
   # get the mount point
-  mountpoint = directory_to_mountpoint(sui_db_dir)
+  mountpoint = pathlib.Path(directory_to_mountpoint(sui_db_dir))
 
   # check if mountpoint is attached to nvme-type disk
-  nvme = directory_to_mountpoint(mountpoint)
+  nvme = directory_on_nvme(mountpoint)
   return (nvme, f"sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {nvme}", None)
 
 

--- a/src/checks.py
+++ b/src/checks.py
@@ -106,7 +106,7 @@ def check_if_sui_db_on_nvme():
   mountpoint = directory_to_mountpoint(sui_db_dir)
 
   # check if mountpoint is attached to nvme-type disk
-  nvme = mountpoint_on_nvme(mountpoint)
+  nvme = directory_to_mountpoint(mountpoint)
   return (nvme, f"sui dir: {sui_db_dir}; mountpoint: {mountpoint}; nvme: {nvme}", None)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -68,7 +68,7 @@ def directory_to_mountpoint(directory: str) -> str:
 
 
 def device_path_to_device_info(device_path: pathlib.Path):
-  cmd_seg_list = ["lsblk", "-JO", device_path.resolve()]
+  cmd_seg_list = ["lsblk", "-JO", device_path.resolve(strict=True)]
   process = subprocess.run(cmd_seg_list, capture_output=True, check=True)
 
   device_info_json = process.stdout.decode("utf-8").strip()
@@ -81,7 +81,7 @@ def device_path_to_device_info(device_path: pathlib.Path):
 
 
 def directory_to_device_path(dir_path: pathlib.Path):
-  cmd_seg_list = ["df", "--output=source", dir_path.resolve()]
+  cmd_seg_list = ["df", "--output=source", dir_path.resolve(strict=True)]
   process = subprocess.run(cmd_seg_list, capture_output=True, check=True)
 
   device_output = process.stdout.decode("utf-8").strip()

--- a/src/utils.py
+++ b/src/utils.py
@@ -68,7 +68,7 @@ def directory_to_mountpoint(directory: str) -> str:
 
 
 def device_path_to_device_info(device_path: pathlib.Path):
-  cmd_seg_list = ["lsblk", "-JO", device_path]
+  cmd_seg_list = ["lsblk", "-JO", device_path.resolve()]
   process = subprocess.run(cmd_seg_list, capture_output=True, check=True)
 
   device_info_json = process.stdout.decode("utf-8").strip()
@@ -81,7 +81,7 @@ def device_path_to_device_info(device_path: pathlib.Path):
 
 
 def directory_to_device_path(dir_path: pathlib.Path):
-  cmd_seg_list = ["df", "--output=source", dir_path]
+  cmd_seg_list = ["df", "--output=source", dir_path.resolve()]
   process = subprocess.run(cmd_seg_list, capture_output=True, check=True)
 
   device_output = process.stdout.decode("utf-8").strip()


### PR DESCRIPTION
@akichidis This was tested on a machine whose root '/' was mounted on NVME: lax-flt-vultr-01.fleet.sui.io

This machine will undergo re-install at some during my day tomorrow but feel free to use/view it for this evening only.